### PR TITLE
Add missing time-aware attribute in xml schema.

### DIFF
--- a/schemas/orm/doctrine-extensions-mapping-2-2.xsd
+++ b/schemas/orm/doctrine-extensions-mapping-2-2.xsd
@@ -87,6 +87,7 @@ people to push their own additional attributes/elements into the same field elem
 
   <xs:complexType name="soft-deleteable">
     <xs:attribute name="field-name" type="xs:string" use="required" />
+    <xs:attribute name="time-aware" type="xs:boolean" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="handler">


### PR DESCRIPTION
According to [documentation](https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/softdeleteable.md#xml-mapping-example) there should be time-aware attribute defined in soft-deleteable type. It is missing.
