### PR TITLE
Import Gedmo annotation

### DIFF
--- a/lib/Gedmo/Timestampable/Traits/TimestampableEntity.php
+++ b/lib/Gedmo/Timestampable/Traits/TimestampableEntity.php
@@ -2,6 +2,8 @@
 
 namespace Gedmo\Timestampable\Traits;
 
+use Gedmo\Mapping\Annotation as Gedmo;
+
 /**
  * Timestampable Trait, usable with PHP >= 5.4
  *
@@ -12,13 +14,13 @@ trait TimestampableEntity
 {
     /**
      * @Gedmo\Timestampable(on="create")
-     * @ORM\Column(type="datetime")
+     * @ORM\Column(name="created_at", type="datetime")
      */
     protected $createdAt;
 
     /**
      * @Gedmo\Timestampable(on="update")
-     * @ORM\Column(type="datetime")
+     * @ORM\Column(name="updated_at", type="datetime")
      */
     protected $updatedAt;
 


### PR DESCRIPTION
Fix for 
  [Doctrine\Common\Annotations\AnnotationException]  
  [Semantical Error] The annotation "@Gedmo\Timestampable" in property %Entity%::$createdAt was never imported. Did you maybe forget to add a "use" statement for this annotation?
