### PR TITLE
Improving loggable extension querying performance

### DIFF
--- a/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
+++ b/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php
@@ -54,7 +54,7 @@ class LogEntryRepository extends EntityRepository
         $dql .= " AND log.objectClass = :objectClass";
         $dql .= " ORDER BY log.version DESC";
 
-        $objectId = $wrapped->getIdentifier();
+        $objectId = (string) $wrapped->getIdentifier();
         $q = $this->_em->createQuery($dql);
         $q->setParameters(compact('objectId', 'objectClass'));
 
@@ -86,7 +86,7 @@ class LogEntryRepository extends EntityRepository
         $dql .= " AND log.version <= :version";
         $dql .= " ORDER BY log.version ASC";
 
-        $objectId = $wrapped->getIdentifier();
+        $objectId = (string) $wrapped->getIdentifier();
         $q = $this->_em->createQuery($dql);
         $q->setParameters(compact('objectId', 'objectClass', 'version'));
         $logs = $q->getResult();


### PR DESCRIPTION
The issue is that the query got by the getLogEntriesQuery method don’t use the correct MySQL index therefore the performance is very low when the ext_log_entries has a several millions of rows.

The problem is that the “object_id” field in ext_log_entries table is a varchar(64) type field.

The table has the next indexes:

 - PRIMARY (id)
 - log_class_lookup_idx (object_class)
 - log_date_lookup_idx (logged_at)
 - log_user_lookup_idx (username)
 - log_version_lookup_idx (object_id, object_class, version)

getLogEntriesQuery method queries entries by objectId, objectClass and ordered by version. The right index should be log_version_lookup_idx but mysql always use log_class_lookup_idx even thought you force the log_version_lookup_idx index. This happens because objectId is stored as a varchar field and then is queried using an integer value. As an example:

   where log.objectId = 1 AND log.objectClass = “AppBundle\Entity\FooClass” ORDER BY log.version DESC -> this uses log_class_lookup_idx index
   where log.objectId = “1” AND log.objectClass = “AppBundle\Entity\FooClass” ORDER BY log.version DESC -> this uses log_version_lookup_idx index

In my case, I have 35 million rows in ext_log_entries table. When I perform a query with log_class_lookup_idx index, it takes several minutes!!! (a lot of time). But the same query with the log_version_lookup_idx takes a few milliseconds (great).

I propose, change the line 57 and 89 on Gedmo/Loggable/Entity/Repository/LogEntryRepository.php 

Original:         $objectId = $wrapped->getIdentifier();
To:               $objectId = (string) $wrapped->getIdentifier();

By this way, Mysql will use log_version_lookup_idx index and it will improve performance in a big way.

Thanks a lot.